### PR TITLE
Add percentage to bc_radio_pub_battery function

### DIFF
--- a/bcl/inc/bc_radio.h
+++ b/bcl/inc/bc_radio.h
@@ -68,7 +68,7 @@ bool bc_radio_pub_barometer(uint8_t i2c, float *pascal, float *meter);
 
 bool bc_radio_pub_co2(float *concentration);
 
-bool bc_radio_pub_battery(uint8_t format, float *voltage);
+bool bc_radio_pub_battery(uint8_t format, float *voltage, float *percentage);
 
 bool bc_radio_pub_buffer(void *buffer, size_t length);
 

--- a/bcl/src/bc_radio.c
+++ b/bcl/src/bc_radio.c
@@ -90,7 +90,7 @@ __attribute__((weak)) void bc_radio_on_humidity(uint64_t *peer_device_address, u
 __attribute__((weak)) void bc_radio_on_lux_meter(uint64_t *peer_device_address, uint8_t *i2c, float *illuminance) { (void) peer_device_address; (void) i2c; (void) illuminance; }
 __attribute__((weak)) void bc_radio_on_barometer(uint64_t *peer_device_address, uint8_t *i2c, float *pressure, float *altitude) { (void) peer_device_address; (void) i2c; (void) pressure; (void) altitude; }
 __attribute__((weak)) void bc_radio_on_co2(uint64_t *peer_device_address, float *concentration) { (void) peer_device_address; (void) concentration; }
-__attribute__((weak)) void bc_radio_on_battery(uint64_t *peer_device_address, uint8_t *format, float *voltage) { (void) peer_device_address; (void) format; (void) voltage; }
+__attribute__((weak)) void bc_radio_on_battery(uint64_t *peer_device_address, uint8_t *format, float *voltage, float *percentage) { (void) peer_device_address; (void) format; (void) voltage; (void) percentage; }
 __attribute__((weak)) void bc_radio_on_buffer(uint64_t *peer_device_address, void *buffer, size_t *length) { (void) peer_device_address; (void) buffer; (void) length; }
 __attribute__((weak)) void bc_radio_on_info(uint64_t *peer_device_address, char *firmware) { (void) peer_device_address; (void) firmware; }
 
@@ -377,14 +377,15 @@ bool bc_radio_pub_co2(float *concentration)
     return true;
 }
 
-bool bc_radio_pub_battery(uint8_t format, float *voltage)
+bool bc_radio_pub_battery(uint8_t format, float *voltage, float *percentage)
 {
-    uint8_t buffer[1 + sizeof(uint8_t) + sizeof(*voltage)];
+    uint8_t buffer[1 + sizeof(uint8_t) + sizeof(*voltage) + sizeof(*percentage)];
 
     buffer[0] = BC_RADIO_HEADER_PUB_BATTERY;
     buffer[1] = format;
 
     memcpy(&buffer[2], voltage, sizeof(*voltage));
+    memcpy(&buffer[2 + sizeof(*voltage)], percentage, sizeof(*percentage));
 
     if (!bc_queue_put(&_bc_radio.pub_queue, buffer, sizeof(buffer)))
     {
@@ -567,10 +568,12 @@ static void _bc_radio_task(void *param)
         else if (queue_item_buffer[8] == BC_RADIO_HEADER_PUB_BATTERY)
         {
             float voltage;
+            float percentage;
 
             memcpy(&voltage, &queue_item_buffer[8 + 2], sizeof(voltage));
+            memcpy(&percentage, &queue_item_buffer[8 + 2 + sizeof(voltage)], sizeof(percentage));
 
-            bc_radio_on_battery(&device_address, &queue_item_buffer[8 + 1], &voltage);
+            bc_radio_on_battery(&device_address, &queue_item_buffer[8 + 1], &voltage, &percentage);
         }
         else if (queue_item_buffer[8] == BC_RADIO_HEADER_PUB_BUFFER)
         {


### PR DESCRIPTION
The battery_module has a function to get voltage and percentage. Only voltage is sent via radio. But for me, as a user, the percentage value is much more useful.

This pull request extends the SDK radio function `bc_radio_pub_battery()`. A new parameter `percentage` was added (inspired by bc_radio_on_barometer() function). Both values `voltage` and `percentage` are sent.

Please note, that other repositories, using `bc_radio_pub_battery()` function, has to be updated as well. Pull requests for bcf-generic-node and bcf-gateway will be sent separately.