### PR TITLE
fix missing parameter in function in bc_led_strip.h

### DIFF
--- a/bcl/inc/bc_led_strip.h
+++ b/bcl/inc/bc_led_strip.h
@@ -78,7 +78,7 @@ bool bc_led_strip_is_ready(bc_led_strip_t *self);
 
 void bc_led_strip_set_brightness(bc_led_strip_t *self, uint8_t brightness);
 
-void bc_led_strip_effect_stop();
+void bc_led_strip_effect_stop(bc_led_strip_t *self);
 
 void bc_led_strip_effect_test(bc_led_strip_t *self);
 


### PR DESCRIPTION
Declaration of *bc_led_strip_effect_stop* function in header file differs from the definition in .c file.