### PR TITLE
Enable Galileo in GPS module

### DIFF
--- a/bcl/inc/bc_sam_m8q.h
+++ b/bcl/inc/bc_sam_m8q.h
@@ -166,7 +166,6 @@ struct bc_sam_m8q_t
     {
         bool valid;
         int fix_quality;
-        int satellites_tracked;
         float altitude;
         char altitude_units;
     } _gga;
@@ -177,6 +176,7 @@ struct bc_sam_m8q_t
         float v_accuracy;
         float speed;
         float course;
+        int satellites;
     } _pubx;
 };
 


### PR DESCRIPTION
Zapnutí podpory evropského navigačního systému Galileo.

## Motivace
Čím více navigačních systémů, tím více satelitů a tím větší přesnost polohy.

## Konfigurace
Celý tento PR je více méně o konfiguraci zařízení.
- Nejdříve jsem zapnul Galileo v GNSS.
- Nic se nestalo, takže jsem pátral a zjistil jsem, že se musí nastavit NMEA protokol na novější verzi 4.1.
- Pak už chodilo tolik zpráv, že z modulu začala chodit systémová zpráva o plném bufferu. Vypl jsem tedy zprávy GSA a GSV, protože ty s počtem navigačních systémů narostou a nepotřebujeme je.
- Nakonec jsem zjistil, že počet satelitů v GGA je jen pro GPS a maximum je 12. Tento údaj tedy beru z PUBX.

Pouze na terase jsem chytl 20 satelitů, ještě vyzkouším venku.