### PR TITLE
Add 4 digit year support, fix day/date bug

### DIFF
--- a/bcl/inc/bc_rtc.h
+++ b/bcl/inc/bc_rtc.h
@@ -18,10 +18,10 @@ typedef struct
 	uint16_t subseconds; //!< Subsecond downcounter. When it reaches zero, it's reload value is the same as @ref RTC_SYNC_PREDIV
 	uint8_t minutes;     //!< Minutes parameter, from 00 to 59
 	uint8_t hours;       //!< Hours parameter, 24Hour mode, 00 to 23
-	uint8_t day;         //!< Day in a week, from 1 to 7
+	uint8_t week_day;         //!< Day in a week, from 1 to 7
 	uint8_t date;        //!< Date in a month, 1 to 31
 	uint8_t month;       //!< Month in a year, 1 to 12
-	uint8_t year;        //!< Year parameter, 00 to 99, 00 is 2000 and 99 is 2099
+	uint16_t year;        //!< Year parameter, 2000 to 2099
 	uint32_t timestamp;  //!< Seconds from 01.01.1970 00:00:00
 } bc_rtc_t;
 
@@ -32,8 +32,10 @@ void bc_rtc_get_date_time(bc_rtc_t* rtc);
 
 //! @brief Set gate and time to RTC
 //! @param[in] rtc Pointer to the RTC date and time structure
+//! @return true On success
+//! @return false On failure
 
-void bc_rtc_set_date_time(bc_rtc_t* rtc);
+bool bc_rtc_set_date_time(bc_rtc_t* rtc);
 
 //! @brief Covert RTC to timestamp
 //! @param[in] rtc Pointer to the RTC date and time structure

--- a/bcl/src/bc_rtc.c
+++ b/bcl/src/bc_rtc.c
@@ -24,7 +24,6 @@ uint32_t bc_rtc_rtc_to_timestamp(bc_rtc_t *rtc)
 {
     uint32_t days = 0, seconds = 0;
     uint16_t i;
-    //uint16_t year = (uint16_t)(rtc->year + 2000);
     // Year is below offset year
     if (rtc->year < _BC_RTC_OFFSET_YEAR)
     {


### PR DESCRIPTION
Be careful that if you have projects that use previous RTC library revision where year had to be converted from for example 19 to 2019 by adding 2000.