### PR TITLE
Fixed GPS module start after stop

### DIFF
--- a/bcl/src/bc_sam_m8q.c
+++ b/bcl/src/bc_sam_m8q.c
@@ -34,6 +34,7 @@ void bc_sam_m8q_start(bc_sam_m8q_t *self)
     if (!self->_running)
     {
         self->_running = true;
+        self->_configured = false;
 
         bc_scheduler_plan_now(self->_task_id);
     }


### PR DESCRIPTION
Fixed reported bug in forum:
https://forum.bigclown.com/t/lora-tester-gps-problem-after-wakeup/498

After GPS module is stopped, all configuration is lost. So I have to send configuration messages again.